### PR TITLE
Vault create implementation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "lib/botan"]
 	path = lib/botan
 	url = https://github.com/randombit/botan.git
+[submodule "lib/trompeloeil"]
+	path = lib/trompeloeil
+	url = https://github.com/rollbear/trompeloeil.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,9 +90,10 @@ target_link_libraries(
     _${CMAKE_PROJECT_NAME}
     CLI11::CLI11
     yaml-cpp::yaml-cpp
-    Catch2::Catch2WithMain
     Botan::Botan-static
 )
+
+add_subdirectory(tests)
 
 # expand search path for include files
 target_include_directories(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,8 +69,25 @@ add_executable(
     ${PROJECT_SOURCE_DIR}/src/${CMAKE_PROJECT_NAME}.cpp
 ) 
 
+# create a library from non-main source files
+# this faciliates easier unit testing
+# add new source files here
+add_library(
+    _${CMAKE_PROJECT_NAME} STATIC
+    ${PROJECT_SOURCE_DIR}/src/cli/command.cpp
+    ${PROJECT_SOURCE_DIR}/src/cli/vault.cpp
+    ${PROJECT_SOURCE_DIR}/src/cli/create.cpp
+    ${PROJECT_SOURCE_DIR}/src/utils/getPass.cpp
+    ${PROJECT_SOURCE_DIR}/src/utils/error.cpp
+)
+
 # link libraries to the executable
-target_link_libraries(${CMAKE_PROJECT_NAME}
+target_link_libraries(
+    ${CMAKE_PROJECT_NAME}
+    _${CMAKE_PROJECT_NAME}
+)
+target_link_libraries(
+    _${CMAKE_PROJECT_NAME}
     CLI11::CLI11
     yaml-cpp::yaml-cpp
     Catch2::Catch2WithMain

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ endif(NOT EXIT_CODE EQUAL "0")
 add_subdirectory(lib/CLI11)
 add_subdirectory(lib/yaml-cpp)
 add_subdirectory(lib/Catch2)
+add_subdirectory(lib/trompeloeil)
 
 # set CLI11 to compile to a static library
 set(CLI11_PRECOMPILED True)

--- a/src/cli/command.cpp
+++ b/src/cli/command.cpp
@@ -1,0 +1,16 @@
+#include "command.hpp"
+#include "create.hpp"
+#include "vault.hpp"
+
+Command::Command(CLI::App* app)
+  : app(app) {};
+
+void
+Commands::setupCommands(CLI::App* app)
+{
+    app->failure_message(CLI::FailureMessage::help);
+    Vault vault = Vault(app);
+    vault.setup();
+    Create create = Create(vault.app);
+    create.setup();
+};

--- a/src/cli/command.hpp
+++ b/src/cli/command.hpp
@@ -1,0 +1,22 @@
+#ifndef COMMAND_H
+#define COMMAND_H
+
+#include <CLI/CLI.hpp>
+#include <string>
+
+class Command
+{
+  public:
+    Command(CLI::App* app);
+    CLI::App* app;
+    std::string name;
+    std::string description;
+    virtual void setup() = 0;
+};
+
+namespace Commands {
+void
+setupCommands(CLI::App* app);
+}
+
+#endif

--- a/src/cli/create.cpp
+++ b/src/cli/create.cpp
@@ -1,0 +1,76 @@
+#include "create.hpp"
+#include "../utils/error.hpp"
+#include "../utils/getPass.hpp"
+#include <fstream>
+
+std::string path;
+
+Create::Create(CLI::App* app)
+  : Command(app) {};
+
+void
+Create::setup()
+{
+    name = "create";
+    description = "Create a vault";
+    app = app->add_subcommand(name, description)
+            ->usage("passman vault create [OPTIONS] PATH")
+            ->callback(f);
+    app->add_option("path", path, "The path of the vault")->required();
+};
+
+void
+createVault(std::string path, getPass_interface& api)
+{
+    namespace fs = std::filesystem;
+    std::ofstream ofs;
+
+    // Check if file already exists
+    try {
+        if (fs::exists(fs::path{ path })) {
+            throw std::invalid_argument{ "file already exists" };
+        }
+    } catch (std::invalid_argument& err) {
+        printErr(path + ": " + err.what());
+        return;
+    }
+
+    // Prompt for password creation
+    try {
+        auto pass1 = api.getPass("Enter password to encrypt vault");
+        auto pass2 = api.getPass("Re-enter password");
+        if (pass1 != pass2) {
+            printErr("passwords do not match");
+            return;
+        }
+    } catch (std::runtime_error err) {
+        printErr(err.what());
+    }
+
+    // Check if file can be opened
+    ofs.open(path, std::ofstream::out);
+    try {
+        if (!ofs.is_open()) {
+            throw std::invalid_argument{ "invalid path" };
+        }
+    } catch (std::invalid_argument& err) {
+        printErr(path + ": " + err.what());
+        return;
+    }
+
+    // TODO: integrate encryption
+
+    // Write to file and close
+    ofs << "Hello from password vault!" << std::endl;
+    ofs.close();
+    if (!ofs.good()) {
+        printErr("error: failed to close file");
+        return;
+    }
+
+    // Print success message
+    std::cout << path << " successfully created" << std::endl;
+};
+
+getPass_api api;
+std::function<void()> f = []() { createVault(path, api); };

--- a/src/cli/create.hpp
+++ b/src/cli/create.hpp
@@ -1,0 +1,23 @@
+#ifndef CREATE_H
+#define CREATE_H
+
+#include "../utils/getPass.hpp"
+#include "command.hpp"
+
+class Create : public Command
+{
+  public:
+    Create(CLI::App* app);
+    void setup();
+};
+
+// Creates a password vault at path.
+// User must enter matching passwords.
+// Prints a success message to stdout if the operation was successful.
+// Prints an error to stderr if the operation was unsuccessful.
+void
+createVault(std::string path, getPass_interface& api);
+
+extern std::function<void()> f;
+
+#endif

--- a/src/cli/vault.cpp
+++ b/src/cli/vault.cpp
@@ -1,0 +1,14 @@
+#include "vault.hpp"
+
+Vault::Vault(CLI::App* app)
+  : Command(app) {};
+
+void
+Vault::setup()
+{
+    name = "vault";
+    description = "Manage vaults";
+    app = app->add_subcommand(name, description)
+            ->usage("passman vault COMMAND [OPTIONS]")
+            ->require_subcommand();
+};

--- a/src/cli/vault.hpp
+++ b/src/cli/vault.hpp
@@ -1,0 +1,13 @@
+#ifndef VAULT_H
+#define VAULT_H
+
+#include "command.hpp"
+
+class Vault : public Command
+{
+  public:
+    Vault(CLI::App* app);
+    void setup();
+};
+
+#endif

--- a/src/passman.cpp
+++ b/src/passman.cpp
@@ -1,51 +1,12 @@
+#include "cli/command.hpp"
 #include <CLI/CLI.hpp>
 #include <string>
 
 int
 main(int argc, char** argv)
 {
-    std::string input_file_name, output_file_name;
-    int level{ 5 }, subopt{ 0 };
-
-    // app caption
-    CLI::App app{ "CLI11 help" };
-
-    app.require_subcommand(1);
-    // subcommands options and flags
-    CLI::App* const encode =
-      app.add_subcommand("e", "encode")->ignore_case(); // ignore case
-    encode->add_option("input", input_file_name, "input file")
-      ->option_text(" ")
-      ->required()
-      ->check(CLI::ExistingFile); // file must exist
-    encode->add_option("output", output_file_name, "output file")
-      ->option_text(" ")
-      ->required(); // required option
-    encode->add_option("-l, --level", level, "encoding level")
-      ->option_text("[1..9]")
-      ->check(CLI::Range(1, 9))
-      ->default_val(5); // limit parameter range
-    encode->add_flag("-R, --remove",
-                     "remove input file"); // no parameter option
-    encode->add_flag("-s, --suboption", subopt, "suboption")->option_text(" ");
-
-    CLI::App* const decode = app.add_subcommand("d", "decode")->ignore_case();
-    decode->add_option("input", input_file_name, "input file")
-      ->option_text(" ")
-      ->required()
-      ->check(CLI::ExistingFile);
-    decode->add_option("output", output_file_name, "output file")
-      ->option_text(" ")
-      ->required();
-
-    // Usage message modification
-    std::string usage_msg = "Usage: " + std::string(argv[0]) +
-                            " <command> [options] <input-file> <output-file>";
-    app.usage(usage_msg);
-    // flag to display full help at once
-    app.set_help_flag("");
-    app.set_help_all_flag("-h, --help");
-
+    CLI::App app;
+    Commands::setupCommands(&app);
     CLI11_PARSE(app, argc, argv);
 
     return 0;

--- a/src/utils/error.cpp
+++ b/src/utils/error.cpp
@@ -1,0 +1,14 @@
+#include "error.hpp"
+#include <iostream>
+
+std::string
+stringErr(std::string msg)
+{
+    return "\033[31merror: \033[0m" + msg;
+};
+
+void
+printErr(std::string msg)
+{
+    std::cerr << stringErr(msg) << std::endl;
+};

--- a/src/utils/error.hpp
+++ b/src/utils/error.hpp
@@ -1,0 +1,13 @@
+#ifndef ERROR_H
+#define ERROR_H
+#include <string>
+
+// Returns msg prepended with text 'error: ' colored red as string.
+std::string
+stringErr(std::string msg);
+
+// Prints msg to stderr prepended with text 'error: ' colored red.
+void
+printErr(std::string msg);
+
+#endif

--- a/src/utils/getPass.cpp
+++ b/src/utils/getPass.cpp
@@ -1,0 +1,34 @@
+#include "getPass.hpp"
+#include "error.hpp"
+#include <iostream>
+#include <termios.h>
+#include <unistd.h>
+
+std::string
+getPass_api::getPass(std::string prompt)
+{
+    std::string pass = "";
+    termios oflags, nflags;
+    tcgetattr(STDIN_FILENO, &oflags);
+    nflags = oflags;
+
+    // Print prompt
+    std::cout << prompt + ": ";
+
+    // Disable echo to stdout
+    nflags.c_lflag ^= ECHO;
+    tcsetattr(STDIN_FILENO, TCSANOW, &nflags);
+
+    // Get input
+    std::getline(std::cin, pass);
+    std::cout << "\n";
+
+    // Restore echo to stdout
+    tcsetattr(STDIN_FILENO, TCSANOW, &oflags);
+
+    if (pass.length() > 4095) {
+        throw std::runtime_error{ "input is too large" };
+    }
+
+    return pass;
+};

--- a/src/utils/getPass.hpp
+++ b/src/utils/getPass.hpp
@@ -1,0 +1,19 @@
+#ifndef GETPASS_H
+#define GETPASS_H
+
+#include <string>
+
+class getPass_interface
+{
+  public:
+    virtual std::string getPass(std::string) = 0;
+};
+
+class getPass_api : public getPass_interface
+{
+  public:
+    // Gets user input without echoing to stdout.
+    std::string getPass(std::string);
+};
+
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.20)
+
+# add the executable
+# add new test files here
+add_executable(
+    test_${CMAKE_PROJECT_NAME} 
+    ${PROJECT_SOURCE_DIR}/tests/test_create.cpp
+    ${PROJECT_SOURCE_DIR}/tests/test_getPass.cpp
+) 
+
+# link libraries to the executable
+target_link_libraries(
+    test_${CMAKE_PROJECT_NAME}
+    _${CMAKE_PROJECT_NAME}
+    Catch2::Catch2WithMain
+    trompeloeil::trompeloeil
+)

--- a/tests/test_create.cpp
+++ b/tests/test_create.cpp
@@ -1,0 +1,106 @@
+#include "../src/cli/create.hpp"
+#include "../src/utils/error.hpp"
+#include "../src/utils/getPass.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/trompeloeil.hpp>
+
+namespace vaultCreateTests {
+class getPass_mock : public getPass_interface
+{
+  public:
+    MAKE_MOCK1(getPass, std::string(std::string), override);
+};
+
+namespace fs = std::filesystem;
+std::string path = "test-vault";
+getPass_mock mock;
+
+TEST_CASE("Given a preexisting vault, a vault is not created and an error "
+          "message is printed to stderr",
+          "[create tests]")
+{
+    // Fail if vault at path exists prior to starting tests
+    if (fs::exists(fs::path{ path })) {
+        printErr(path + " already exists. Remove before starting tests.");
+        exit(EXIT_FAILURE);
+    }
+    // Create preexisting vault
+    std::ofstream ofs;
+    ofs.open(path);
+    // Redirect stderr to stringstream
+    std::stringstream local;
+    auto cerr_buff = std::cerr.rdbuf();
+    std::cerr.rdbuf(local.rdbuf());
+
+    createVault(path, mock);
+    REQUIRE(local.str() == stringErr(path + ": file already exists\n"));
+
+    // Restore stderr
+    std::cerr.rdbuf(cerr_buff);
+    // Delete vault
+    fs::remove(fs::path{ path });
+}
+
+TEST_CASE("Given a nonexisting vault, test branching logic", "[create tests]")
+{
+    // Redirect stderr to stringstream
+    std::stringstream local;
+    auto cerr_buff = std::cerr.rdbuf();
+    std::cerr.rdbuf(local.rdbuf());
+
+    SECTION("Given Matching passwords")
+    {
+        SECTION("Given a valid path, vault is created and success message is "
+                "printed to stdout")
+        {
+            // Redirect stdout to stringstream
+            std::stringstream local;
+            auto cout_buff = std::cout.rdbuf();
+            std::cout.rdbuf(local.rdbuf());
+            {
+                REQUIRE_CALL(mock, getPass("Enter password to encrypt vault"))
+                  .RETURN("pa$$w0rd");
+                REQUIRE_CALL(mock, getPass("Re-enter password"))
+                  .RETURN("pa$$w0rd");
+                createVault(path, mock);
+            }
+            REQUIRE(fs::exists(fs::path{ path }));
+            REQUIRE(local.str() == path + " successfully created\n");
+            std::cout.rdbuf(cout_buff);
+            fs::remove(fs::path{ path });
+        }
+
+        SECTION("Given an invalid path, a vault is not created and an error "
+                "message is printed to stderr")
+        {
+            std::string path = "test-vault/";
+            {
+                REQUIRE_CALL(mock, getPass("Enter password to encrypt vault"))
+                  .RETURN("pa$$w0rd");
+                REQUIRE_CALL(mock, getPass("Re-enter password"))
+                  .RETURN("pa$$w0rd");
+                createVault(path, mock);
+            }
+            REQUIRE(!fs::exists(fs::path{ path }));
+            REQUIRE(local.str() == stringErr(path + ": invalid path\n"));
+        }
+    }
+
+    SECTION("Given different passwords, a vault is not created and an error "
+            "message is printed to stderr")
+    {
+        {
+            REQUIRE_CALL(mock, getPass("Enter password to encrypt vault"))
+              .RETURN("pa$$w0rd111");
+            REQUIRE_CALL(mock, getPass("Re-enter password"))
+              .RETURN("pa$$w0rd222");
+            createVault(path, mock);
+        }
+        REQUIRE(!fs::exists(fs::path{ path }));
+        REQUIRE(local.str() == stringErr("passwords do not match\n"));
+    }
+
+    // Restore stderr
+    std::cerr.rdbuf(cerr_buff);
+}
+}

--- a/tests/test_getPass.cpp
+++ b/tests/test_getPass.cpp
@@ -1,0 +1,60 @@
+#include "../src/utils/getPass.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_templated.hpp>
+#include <catch2/trompeloeil.hpp>
+#include <iostream>
+
+namespace getPassTests {
+class getPass_mock : public getPass_interface
+{
+  public:
+    MAKE_MOCK1(getPass, std::string(std::string), override);
+};
+
+TEST_CASE("Given a call to getPass", "[getPass tests]")
+{
+    // Redirect stdin to stringstream
+    std::stringstream ss_cin;
+    auto cin_buff = std::cin.rdbuf();
+    std::cin.rdbuf(ss_cin.rdbuf());
+
+    // Redirect stdout to stringstream
+    std::stringstream ss_cout;
+    auto cout_buff = std::cout.rdbuf();
+    std::cout.rdbuf(ss_cout.rdbuf());
+
+    getPass_api api;
+
+    SECTION("getPass returns the input password on success")
+    {
+        std::string pass = "pa$$w0rd";
+        ss_cin << pass;
+        REQUIRE(api.getPass("") == pass);
+    }
+
+    SECTION("getPass throws an error for password lengths > 4095 chars")
+    {
+        // Create input > 4095 chars and store to stringstream
+        std::string pass;
+        pass.append(4096, 'f');
+        ss_cin << pass;
+
+        REQUIRE_THROWS_AS(api.getPass(""), std::runtime_error);
+        std::cin.seekg(0);
+        REQUIRE_THROWS_WITH(api.getPass(""), "input is too large");
+    }
+
+    SECTION("getPass prints a prompt containing the argument received")
+    {
+        std::string pass = "pa$$w0rd";
+        ss_cin << pass;
+        std::string prompt = "Enter password to encrypt vault";
+        api.getPass(prompt);
+        REQUIRE(ss_cout.str() == prompt + ": \n");
+    }
+
+    // Restore streams
+    std::cin.rdbuf(cin_buff);
+    std::cout.rdbuf(cout_buff);
+}
+}


### PR DESCRIPTION
- Implemented the `vault create` command
  -  Inheritance: `Command` <- `Vault` <- `Create`
  - Added supporting functions to src/utils
 - Added unit tests for `create` and `getPass`
   - Added trompeloeil mock library
   - Modified CMakeListsts.txt so that source files other than `passman.cpp` build to a library. This library can be linked against the `passman` and `passman-test` executable.